### PR TITLE
Resolvidos os problemas com a pagina de login e os erros envolvendo o upload de noticias e imagens, usando lifecycle postStart.

### DIFF
--- a/aula12/sistema-noticias-statefulset.yaml
+++ b/aula12/sistema-noticias-statefulset.yaml
@@ -15,6 +15,17 @@ spec:
           image: aluracursos/sistema-noticias:1
           ports:
             - containerPort: 80
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                    - /bin/bash
+                    - -c
+                    - >
+                        chown -R www-data /tmp &&
+                        chgrp -R www-data /var/www/html/uploads &&
+                        chmod -R 777 /var/www/html/uploads &&
+                        find /var/www/html/uploads -type d -exec chmod g+s {} +
           envFrom:
             - configMapRef:
                 name: sistema-configmap

--- a/aula12/sistema-noticias-statefulset.yaml
+++ b/aula12/sistema-noticias-statefulset.yaml
@@ -24,7 +24,6 @@ spec:
                     - >
                         chown -R www-data /tmp &&
                         chgrp -R www-data /var/www/html/uploads &&
-                        chmod -R 777 /var/www/html/uploads &&
                         find /var/www/html/uploads -type d -exec chmod g+s {} +
           envFrom:
             - configMapRef:

--- a/aula13/Docker-Sistema/Dockerfile
+++ b/aula13/Docker-Sistema/Dockerfile
@@ -1,0 +1,11 @@
+FROM fernandomj90/alura-sistema-teste2
+
+CMD sudo chgrp -R www-data /var/www/html/
+CMD sudo chown -R www-data /var/www/html/
+CMD sudo chmod -R g+w /var/www/html/
+CMD find /var/www/html/ -type d -exec chmod g+s {} + 
+CMD sudo chown -R www-data /tmp
+
+ENTRYPOINT /bin/bash
+
+USER www-data

--- a/aula6/portal-configmap.yaml
+++ b/aula6/portal-configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: portal-configmap
 data:
-  IP_SISTEMA: http://a1d7c7ba7ee504b3490e584be507a291-1284722871.us-east-1.elb.amazonaws.com/
+  IP_SISTEMA: http://af4b4ac3403df4232930b06bfe297f4d-445413837.us-east-1.elb.amazonaws.com/


### PR DESCRIPTION
Resolvidos os problemas com a pagina de login e os erros envolvendo o upload de noticias e imagens, usando lifecycle postStart.
Removido chmod 777 do Lifecycle postStart no manifesto do Statefulset.